### PR TITLE
feat: Add `setGeneralTimezones` method.

### DIFF
--- a/src/Facades/Timezonelist.php
+++ b/src/Facades/Timezonelist.php
@@ -10,7 +10,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Jackiedo\Timezonelist\Timezonelist onlyGroups(array $groups=[])                                                   Set the filter of the groups want to get.
  * @method static \Jackiedo\Timezonelist\Timezonelist excludeGroups(array $groups=[])                                                Set the filter of the groups do not want to get.
  * @method static \Jackiedo\Timezonelist\Timezonelist splitGroup(bool $status=true)                                                  Decide whether to split group or not.
- * @method statis \Jackiedo\Timezonelist\Timezonelist showOffset(bool $status=true)                                                  Decide whether to show the offset or not.
+ * @method static \Jackiedo\Timezonelist\Timezonelist showOffset(bool $status=true)                                                  Decide whether to show the offset or not.
+ * @method static \Jackiedo\Timezonelist\Timezonelist setGeneralTimezones(array $timezones=[])                                       Sets the timezones available to show as general timezones.
  * @method static \Jackiedo\Timezonelist\Timezonelist reset()                                                                        Return new static to reset all config.
  * @method static string toSelectBox(string $name, null|string $selected=null, null|array|string $attrs=null, bool $htmlencode=true) Create a select box of timezones.
  * @method static string create(string $name, null|string $selected=null, null|array|string $attrs=null, bool $htmlencode=true)      Alias of the `toSelectBox()` method.

--- a/src/Timezonelist.php
+++ b/src/Timezonelist.php
@@ -368,6 +368,20 @@ class Timezonelist
     }
 
     /**
+     * Sets the timezones available to show as general timezones.
+     *
+     * @param array $timezones
+     *
+     * @return $this
+     */
+    protected function setGeneralTimezones(array $timezones)
+    {
+        $this->generalTimezones = $timezones;
+
+        return $this;
+    }
+
+    /**
      * Format to display timezones.
      *
      * @param string      $timezone


### PR DESCRIPTION
This PR adds the capability to change the `generalTimezones`.

## Before

```php
$timezones = new Timezonelist();
$reflected = new \ReflectionClass($timezones);

// @phpstan-ignore-next-line
$property = tap($reflected->getProperty('generalTimezones'))
    ->setAccessible(true)
    ->setValue($timezones, ['UTC']);

return $reflected->getMethod('toArray')->invoke($timezones, false);
```

## After

```php
return Timezonelist::setGeneralTimezones(['UTC'])->toArray(false);
```

> PS: Also found a typo on the facade docblock `statis` instead of `static`.

Cheers.